### PR TITLE
Allow no items in the request

### DIFF
--- a/src/CXml/Builder/PunchOutOrderMessageBuilder.php
+++ b/src/CXml/Builder/PunchOutOrderMessageBuilder.php
@@ -21,7 +21,6 @@ use CXml\Model\ShipTo;
 use CXml\Model\Tax;
 use CXml\Model\TransportInformation;
 use DateTimeInterface;
-use RuntimeException;
 
 use function round;
 

--- a/src/CXml/Builder/PunchOutOrderMessageBuilder.php
+++ b/src/CXml/Builder/PunchOutOrderMessageBuilder.php
@@ -188,10 +188,6 @@ class PunchOutOrderMessageBuilder
 
     public function build(): PunchOutOrderMessage
     {
-        if ([] === $this->punchoutOrderMessageItems) {
-            throw new RuntimeException('Cannot build PunchOutOrderMessage without any PunchoutOrderMessageItem');
-        }
-
         $punchoutOrderMessageHeader = new PunchOutOrderMessageHeader(
             new MoneyWrapper($this->currency, $this->total),
             $this->shipping,


### PR DESCRIPTION
It seems that no items in the cart is a valid case for cXML flow as well.
Happens when customer wants to just get back to the eProcument platform.